### PR TITLE
Refactor improvements

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-unknown-unknown"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/
+.vs/
 
 static/pkg
 target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 wasm-bindgen = "0.2.62"
 js-sys = "0.3.39"
 yew = "0.16.2"
-serde = "1.0.104"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.53"
 base64 = "0.12.1"
 wasm-bindgen-futures = "0.4.13"

--- a/src/chat/chat_model.rs
+++ b/src/chat/chat_model.rs
@@ -526,7 +526,7 @@ impl<T: NetworkManager + 'static> ChatModel<T> {
 
     fn get_serialized_offer_and_candidates(&self) -> String {
         let connection_string = ConnectionString {
-            offer: self.web_rtc_manager.borrow().get_offer(),
+            offer: self.web_rtc_manager.borrow().get_offer().expect("no offer yet"),
             ice_candidates: self.web_rtc_manager.borrow().get_ice_candidates(),
         };
 

--- a/src/chat/chat_model.rs
+++ b/src/chat/chat_model.rs
@@ -34,8 +34,8 @@ pub struct Message {
 impl Message {
     pub fn new(content: String, sender: MessageSender) -> Message {
         Message {
-            content: content,
-            sender: sender,
+            content,
+            sender,
         }
     }
 }
@@ -95,8 +95,8 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
                     .borrow_mut()
                     .set_state(State::Server(ConnectionState::new()));
                 T::start_web_rtc(self.web_rtc_manager.clone()).expect("Failed to start WebRTC manager");
-                let re_render = true;
-                return re_render;
+                
+                true
             }
 
             Msg::ConnectToServer => {
@@ -104,8 +104,8 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
                     .borrow_mut()
                     .set_state(State::Client(ConnectionState::new()));
                 T::start_web_rtc(self.web_rtc_manager.clone()).expect("Failed to start WebRTC manager");
-                let re_render = true;
-                return re_render;
+                
+                true
             }
 
             Msg::UpdateWebRTCState(web_rtc_state) => {
@@ -118,8 +118,8 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
                 // let hash_as_string = hex::encode(hash);
                 // console::log_1(&hash_as_string.into());
 
-                let re_render = true;
-                return re_render;
+                
+                true
             }
 
             Msg::ResetWebRTC => {
@@ -128,20 +128,20 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
                 self.chat_value = "".into();
                 self.value = "".into();
 
-                let re_render = true;
-                return re_render;
+                
+                true
             }
 
             Msg::UpdateInputValue(val) => {
                 self.value = val;
-                let re_render = true;
-                return re_render;
+                
+                true
             }
 
             Msg::UpdateInputChatValue(val) => {
                 self.chat_value = val;
-                let re_render = true;
-                return re_render;
+                
+                true
             }
 
             Msg::ValidateOffer => {
@@ -184,15 +184,15 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
                     }
                 };
 
-                let re_render = true;
-                return re_render;
+                
+                true
             }
 
             Msg::NewMessage(message) => {
                 self.messages.push(message);
                 self.scroll_top();
-                let re_render = true;
-                return re_render;
+                
+                true
             }
 
             Msg::Send => {
@@ -201,8 +201,8 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
                 self.web_rtc_manager.borrow().send_message(&self.chat_value);
                 self.chat_value = "".into();
                 self.scroll_top();
-                let re_render = true;
-                return re_render;
+                
+                true
             }
 
             Msg::Disconnect => {
@@ -210,8 +210,8 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
                 self.messages = vec![];
                 self.chat_value = "".into();
                 self.value = "".into();
-                let re_render = true;
-                return re_render;
+                
+                true
             }
 
             Msg::OnKeyUp(event) => {
@@ -224,14 +224,14 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
                     self.chat_value = "".into();
                     self.scroll_top();
                 }
-                let re_render = true;
-                return re_render;
+                
+                true
             }
 
             Msg::CopyToClipboard => {
                 self.copy_content_to_clipboard();
-                let re_render = true;
-                return re_render;
+                
+                true
             }
         }
     }
@@ -242,7 +242,7 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
 
     fn view(&self) -> Html {
         match &self.web_rtc_manager.borrow().get_state() {
-            State::DefaultState => {
+            State::Default => {
                 html! {
                     <>
                         { self.get_chat_header() }
@@ -435,7 +435,7 @@ impl<T: NetworkManager + 'static> ChatModel<T> {
 
     fn get_chat_header(&self) -> Html {
         let is_disconnect_button_visible =
-            self.web_rtc_manager.borrow().get_state() != State::DefaultState;
+            self.web_rtc_manager.borrow().get_state() != State::Default;
         html! {
             <header class="msger-header">
                 <div style="font-size:25">
@@ -467,24 +467,14 @@ impl<T: NetworkManager + 'static> ChatModel<T> {
 
     fn is_chat_enabled(&self) -> bool {
         match &self.web_rtc_manager.borrow().get_state() {
-            State::DefaultState => false,
+            State::Default => false,
             State::Server(connection_state) => {
-                if connection_state.data_channel_state.is_some()
+                connection_state.data_channel_state.is_some()
                     && connection_state.data_channel_state.unwrap() == RtcDataChannelState::Open
-                {
-                    true
-                } else {
-                    false
-                }
             }
             State::Client(connection_state) => {
-                if connection_state.data_channel_state.is_some()
+                connection_state.data_channel_state.is_some()
                     && connection_state.data_channel_state.unwrap() == RtcDataChannelState::Open
-                {
-                    true
-                } else {
-                    false
-                }
             }
         }
     }
@@ -557,9 +547,9 @@ impl<T: NetworkManager + 'static> ChatModel<T> {
         };
 
         let serialized: String = serde_json::to_string(&connection_string).unwrap();
-        let encoded = base64::encode(serialized);
+        
 
-        encoded
+        base64::encode(serialized)
     }
 
     fn get_offer_and_candidates(&self) -> Html {
@@ -587,7 +577,7 @@ impl<T: NetworkManager + 'static> ChatModel<T> {
         let state = self.web_rtc_manager.borrow().get_state();
 
         let html = match state {
-            State::DefaultState => html! { <div style="font-size:8;"> { "|Default State|"} </div> },
+            State::Default => html! { <div style="font-size:8;"> { "|Default State|"} </div> },
             State::Server(connection_state) => html! {
                 <div style="font-size:8;">
                     { "|Server|"}
@@ -615,7 +605,7 @@ impl<T: NetworkManager + 'static> ChatModel<T> {
         let aux = document.create_element("input").unwrap();
         let aux = aux.dyn_into::<web_sys::HtmlInputElement>().unwrap();
         let content: String = document
-            .get_element_by_id("copy-elem".into())
+            .get_element_by_id("copy-elem")
             .unwrap()
             .inner_html();
         let _result = aux.set_attribute("value", &content);
@@ -659,7 +649,7 @@ impl<T: NetworkManager + 'static> ChatModel<T> {
 
 fn get_debug_state_string(state: &State) -> String {
     match state {
-        State::DefaultState => "Default State".into(),
+        State::Default => "Default State".into(),
         State::Server(connection_state) => format!(
             "{}\nice gathering: {:?}\nice connection: {:?}\ndata channel: {:?}\n",
             "Server",

--- a/src/chat/chat_model.rs
+++ b/src/chat/chat_model.rs
@@ -78,20 +78,14 @@ impl Component for ChatModel {
     type Properties = ();
 
     fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
-        let web_rtc_manager = WebRTCManager::create_default(link.clone());
-
-        let rc = Rc::new(RefCell::new(web_rtc_manager));
-
-        let model = ChatModel {
-            web_rtc_manager: rc.clone(),
+        ChatModel {
+            web_rtc_manager: WebRTCManager::new(link.clone()),
             messages: vec![],
-            link: link,
+            link,
             value: "".into(),
             chat_value: "".into(),
             node_ref: NodeRef::default(),
-        };
-
-        model
+        }
     }
 
     fn change(&mut self, _: Self::Properties) -> ShouldRender {
@@ -133,9 +127,7 @@ impl Component for ChatModel {
             }
 
             Msg::ResetWebRTC => {
-                let web_rtc_manager = WebRTCManager::create_default(self.link.clone());
-                let rc = Rc::new(RefCell::new(web_rtc_manager));
-                self.web_rtc_manager = rc;
+                self.web_rtc_manager = WebRTCManager::new(self.link.clone());
                 self.messages = vec![];
                 self.chat_value = "".into();
                 self.value = "".into();
@@ -219,9 +211,7 @@ impl Component for ChatModel {
             }
 
             Msg::Disconnect => {
-                let web_rtc_manager = WebRTCManager::create_default(self.link.clone());
-                let rc = Rc::new(RefCell::new(web_rtc_manager));
-                self.web_rtc_manager = rc;
+                self.web_rtc_manager = WebRTCManager::new(self.link.clone());
                 self.messages = vec![];
                 self.chat_value = "".into();
                 self.value = "".into();

--- a/src/chat/chat_model.rs
+++ b/src/chat/chat_model.rs
@@ -200,10 +200,9 @@ impl Component for ChatModel {
             }
 
             Msg::Send => {
-                let content = self.chat_value.clone();
-                let my_message = Message::new(content.clone(), MessageSender::Me);
+                let my_message = Message::new(self.chat_value.clone(), MessageSender::Me);
                 self.messages.push(my_message);
-                self.web_rtc_manager.borrow().send_message(content);
+                self.web_rtc_manager.borrow().send_message(&self.chat_value);
                 self.chat_value = "".into();
                 self.scroll_top();
                 let re_render = true;
@@ -225,7 +224,7 @@ impl Component for ChatModel {
                     self.messages.push(my_message);
                     self.web_rtc_manager
                         .borrow()
-                        .send_message(self.chat_value.clone());
+                        .send_message(&self.chat_value);
                     self.chat_value = "".into();
                     self.scroll_top();
                 }
@@ -440,7 +439,7 @@ impl ChatModel {
         html! {
             <header class="msger-header">
                 <div style="font-size:25">
-                    {"Rust WebRTC WASM Chat V2"}
+                    {"Rust WebRTC WASM Chat V2.1"}
                 </div>
 
                 { self.get_debug_html() }

--- a/src/chat/chat_model.rs
+++ b/src/chat/chat_model.rs
@@ -104,7 +104,7 @@ impl Component for ChatModel {
                 self.web_rtc_manager
                     .borrow_mut()
                     .set_state(State::Server(ConnectionState::new()));
-                WebRTCManager::start_web_rtc(self.web_rtc_manager.clone());
+                WebRTCManager::start_web_rtc(self.web_rtc_manager.clone()).expect("Failed to start WebRTC manager");
                 let re_render = true;
                 return re_render;
             }
@@ -113,7 +113,7 @@ impl Component for ChatModel {
                 self.web_rtc_manager
                     .borrow_mut()
                     .set_state(State::Client(ConnectionState::new()));
-                WebRTCManager::start_web_rtc(self.web_rtc_manager.clone());
+                WebRTCManager::start_web_rtc(self.web_rtc_manager.clone()).expect("Failed to start WebRTC manager");
                 let re_render = true;
                 return re_render;
             }
@@ -450,7 +450,7 @@ impl ChatModel {
         html! {
             <header class="msger-header">
                 <div style="font-size:25">
-                    {"Rust WebRTC WASM Chat V1"}
+                    {"Rust WebRTC WASM Chat V2"}
                 </div>
 
                 { self.get_debug_html() }

--- a/src/chat/chat_model.rs
+++ b/src/chat/chat_model.rs
@@ -12,8 +12,7 @@ use base64;
 use serde::{Deserialize, Serialize};
 
 use yew::{
-    html, html::NodeRef, Component, ComponentLink, Html, InputData, KeyboardEvent,
-    ShouldRender,
+    html, html::NodeRef, Component, ComponentLink, Html, InputData, KeyboardEvent, ShouldRender,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -30,10 +29,7 @@ pub struct Message {
 
 impl Message {
     pub fn new(content: String, sender: MessageSender) -> Message {
-        Message {
-            content,
-            sender,
-        }
+        Message { content, sender }
     }
 }
 
@@ -91,8 +87,9 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
                 self.web_rtc_manager
                     .borrow_mut()
                     .set_state(State::Server(ConnectionState::new()));
-                T::start_web_rtc(self.web_rtc_manager.clone()).expect("Failed to start WebRTC manager");
-                
+                T::start_web_rtc(self.web_rtc_manager.clone())
+                    .expect("Failed to start WebRTC manager");
+
                 true
             }
 
@@ -100,8 +97,9 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
                 self.web_rtc_manager
                     .borrow_mut()
                     .set_state(State::Client(ConnectionState::new()));
-                T::start_web_rtc(self.web_rtc_manager.clone()).expect("Failed to start WebRTC manager");
-                
+                T::start_web_rtc(self.web_rtc_manager.clone())
+                    .expect("Failed to start WebRTC manager");
+
                 true
             }
 
@@ -115,7 +113,6 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
                 // let hash_as_string = hex::encode(hash);
                 // console::log_1(&hash_as_string.into());
 
-                
                 true
             }
 
@@ -125,19 +122,18 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
                 self.chat_value = "".into();
                 self.value = "".into();
 
-                
                 true
             }
 
             Msg::UpdateInputValue(val) => {
                 self.value = val;
-                
+
                 true
             }
 
             Msg::UpdateInputChatValue(val) => {
                 self.chat_value = val;
-                
+
                 true
             }
 
@@ -146,10 +142,7 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
 
                 match state {
                     State::Server(_connection_state) => {
-                        let result = T::validate_answer(
-                            self.web_rtc_manager.clone(),
-                            &self.value,
-                        );
+                        let result = T::validate_answer(self.web_rtc_manager.clone(), &self.value);
 
                         if result.is_err() {
                             web_sys::Window::alert_with_message(
@@ -163,10 +156,7 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
                         }
                     }
                     _ => {
-                        let result = T::validate_offer(
-                            self.web_rtc_manager.clone(),
-                            &self.value,
-                        );
+                        let result = T::validate_offer(self.web_rtc_manager.clone(), &self.value);
 
                         if result.is_err() {
                             web_sys::Window::alert_with_message(
@@ -181,14 +171,13 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
                     }
                 };
 
-                
                 true
             }
 
             Msg::NewMessage(message) => {
                 self.messages.push(message);
                 self.scroll_top();
-                
+
                 true
             }
 
@@ -198,7 +187,7 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
                 self.web_rtc_manager.borrow().send_message(&self.chat_value);
                 self.chat_value = "".into();
                 self.scroll_top();
-                
+
                 true
             }
 
@@ -207,7 +196,7 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
                 self.messages = vec![];
                 self.chat_value = "".into();
                 self.value = "".into();
-                
+
                 true
             }
 
@@ -215,19 +204,17 @@ impl<T: NetworkManager + 'static> Component for ChatModel<T> {
                 if event.key_code() == 13 && !self.chat_value.is_empty() {
                     let my_message = Message::new(self.chat_value.clone(), MessageSender::Me);
                     self.messages.push(my_message);
-                    self.web_rtc_manager
-                        .borrow()
-                        .send_message(&self.chat_value);
+                    self.web_rtc_manager.borrow().send_message(&self.chat_value);
                     self.chat_value = "".into();
                     self.scroll_top();
                 }
-                
+
                 true
             }
 
             Msg::CopyToClipboard => {
                 self.copy_content_to_clipboard();
-                
+
                 true
             }
         }
@@ -544,7 +531,6 @@ impl<T: NetworkManager + 'static> ChatModel<T> {
         };
 
         let serialized: String = serde_json::to_string(&connection_string).unwrap();
-        
 
         base64::encode(serialized)
     }

--- a/src/chat/chat_model.rs
+++ b/src/chat/chat_model.rs
@@ -9,13 +9,10 @@ use std::rc::Rc;
 use std::str;
 
 use base64;
-#[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
-#[allow(unused_imports)]
-use yew::services::{ConsoleService, IntervalService, Task, TimeoutService};
-#[allow(unused_imports)]
+
 use yew::{
-    html, html::NodeRef, App, Callback, Component, ComponentLink, Html, InputData, KeyboardEvent,
+    html, html::NodeRef, Component, ComponentLink, Html, InputData, KeyboardEvent,
     ShouldRender,
 };
 
@@ -439,7 +436,7 @@ impl<T: NetworkManager + 'static> ChatModel<T> {
         html! {
             <header class="msger-header">
                 <div style="font-size:25">
-                    {"Rust WebRTC WASM Chat V2.2"}
+                    {"Rust WebRTC WASM Chat V2.3"}
                 </div>
 
                 { self.get_debug_html() }

--- a/src/chat/chat_model.rs
+++ b/src/chat/chat_model.rs
@@ -1,9 +1,3 @@
-use wasm_bindgen::JsCast;
-use wasm_bindgen_futures::spawn_local;
-use web_sys::*;
-
-use crate::chat::web_rtc_manager::*;
-
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::str;
@@ -11,9 +5,16 @@ use std::str;
 use base64;
 use serde::{Deserialize, Serialize};
 
+use web_sys::{console, Element, RtcDataChannelState};
+
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::spawn_local;
+
 use yew::{
     html, html::NodeRef, Component, ComponentLink, Html, InputData, KeyboardEvent, ShouldRender,
 };
+
+use crate::chat::web_rtc_manager::{ConnectionState, IceCandidate, NetworkManager, State};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum MessageSender {
@@ -526,7 +527,11 @@ impl<T: NetworkManager + 'static> ChatModel<T> {
 
     fn get_serialized_offer_and_candidates(&self) -> String {
         let connection_string = ConnectionString {
-            offer: self.web_rtc_manager.borrow().get_offer().expect("no offer yet"),
+            offer: self
+                .web_rtc_manager
+                .borrow()
+                .get_offer()
+                .expect("no offer yet"),
             ice_candidates: self.web_rtc_manager.borrow().get_ice_candidates(),
         };
 

--- a/src/chat/web_rtc_manager.rs
+++ b/src/chat/web_rtc_manager.rs
@@ -67,7 +67,7 @@ pub trait NetworkManager {
     fn send_message(&self, message_content: &str);
     fn get_state(&self) -> State;
     fn set_state(&mut self, new_state: State);
-    fn get_offer(&self) -> String;
+    fn get_offer(&self) -> Option<String>;
     fn get_ice_candidates(&self) -> Vec<IceCandidate>;
     fn validate_offer(web_rtc_manager: Rc<RefCell<Self>>, str: &str) -> Result<(), OfferError>;
     fn validate_answer(web_rtc_manager: Rc<RefCell<Self>>, str: &str) -> Result<(), OfferError>;
@@ -80,7 +80,7 @@ pub struct WebRTCManager {
     data_channel: Option<RtcDataChannel>,
     exit_offer_or_answer_early: bool,
     ice_candidates: Vec<IceCandidate>,
-    offer: String,
+    offer: Option<String>,
     parent_link: ComponentLink<ChatModel<Self>>,
 }
 
@@ -91,7 +91,7 @@ impl NetworkManager for WebRTCManager {
             rtc_peer_connection: None,
             data_channel: None,
             ice_candidates: Vec::new(),
-            offer: "".into(),
+            offer: None,
             parent_link: link,
             exit_offer_or_answer_early: false,
         }))
@@ -115,7 +115,7 @@ impl NetworkManager for WebRTCManager {
         self.state = new_state;
     }
 
-    fn get_offer(&self) -> String {
+    fn get_offer(&self) -> Option<String> {
         self.offer.clone()
     }
 
@@ -194,7 +194,7 @@ impl NetworkManager for WebRTCManager {
                 console::log_1(&answer.clone().into());
 
                 web_rtc_manager_rc_clone_clone.borrow_mut().offer =
-                    String::from(JSON::stringify(&answer).unwrap());
+                    Some(String::from(JSON::stringify(&answer).unwrap()));
             }) as SingleArgJsFn);
 
             // TODO: .await this
@@ -343,7 +343,7 @@ impl NetworkManager for WebRTCManager {
                     console::log_1(&rtc_session_description.clone().into());
 
                     web_rtc_manager_rc_clone.borrow_mut().offer =
-                        String::from(JSON::stringify(&rtc_session_description).unwrap());
+                        Some(String::from(JSON::stringify(&rtc_session_description).unwrap()));
 
                     let set_local_description_exception_handler =
                         WebRTCManager::get_exception_handler(

--- a/src/chat/web_rtc_manager.rs
+++ b/src/chat/web_rtc_manager.rs
@@ -69,6 +69,10 @@ pub struct IceCandidate {
     sdp_m_line_index: u16,
 }
 
+trait NetworkManager {
+
+}
+
 pub struct WebRTCManager {
     state: State,
     rtc_peer_connection: Option<RtcPeerConnection>,
@@ -80,8 +84,8 @@ pub struct WebRTCManager {
 }
 
 impl WebRTCManager {
-    pub fn create_default(link: ComponentLink<ChatModel>) -> WebRTCManager {
-        let web_rtc_manager = WebRTCManager {
+    pub fn new(link: ComponentLink<ChatModel>) -> Rc<RefCell<WebRTCManager>> {
+        Rc::new(RefCell::new(WebRTCManager {
             state: State::DefaultState,
             rtc_peer_connection: None,
             data_channel: None,
@@ -89,9 +93,7 @@ impl WebRTCManager {
             offer: "".into(),
             parent_link: link,
             exit_offer_or_answer_early: false,
-        };
-
-        web_rtc_manager
+        }))
     }
 
     pub fn send_message(&self, message_content: String) {

--- a/src/chat/web_rtc_manager.rs
+++ b/src/chat/web_rtc_manager.rs
@@ -11,6 +11,7 @@ use std::str;
 
 use base64;
 use serde::{Deserialize, Serialize};
+use wasm_bindgen_futures::JsFuture;
 
 use yew::{ComponentLink};
 
@@ -201,7 +202,8 @@ impl NetworkManager for WebRTCManager {
                     String::from(JSON::stringify(&answer).unwrap());
             }) as SingleArgJsFn);
 
-            web_rtc_manager_rc_clone
+            // TODO: .await this
+            JsFuture::from(web_rtc_manager_rc_clone
                 .borrow()
                 .rtc_peer_connection
                 .as_ref()
@@ -209,13 +211,11 @@ impl NetworkManager for WebRTCManager {
                 .create_answer()
                 .then(&set_local_description_closure)
                 .catch(&create_answer_exception_handler)
-                .then(&set_candidates_closure);
+                .then(&set_candidates_closure));
 
             set_candidates_closure.forget();
             set_local_description_closure.forget();
         });
-
-
 
         let create_answer_closure = Closure::wrap(create_answer_function);
 

--- a/src/chat/web_rtc_manager.rs
+++ b/src/chat/web_rtc_manager.rs
@@ -1,18 +1,23 @@
-use js_sys::*;
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
-use web_sys::*;
+use wasm_bindgen::{JsCast, JsValue};
 
-use crate::chat::chat_model::*;
+use crate::chat::chat_model::{ChatModel, ConnectionString, Msg};
 
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::str;
 
 use base64;
+use js_sys::{Array, Object, Reflect, JSON};
 use serde::{Deserialize, Serialize};
+use wasm_bindgen::closure::Closure;
 use wasm_bindgen_futures::JsFuture;
+use web_sys::{
+    console, RtcConfiguration, RtcDataChannel, RtcDataChannelEvent, RtcDataChannelInit,
+    RtcDataChannelState, RtcIceCandidate, RtcIceCandidateInit, RtcIceConnectionState,
+    RtcIceGatheringState, RtcPeerConnection, RtcPeerConnectionIceEvent, RtcSessionDescriptionInit,
+};
 
+use crate::{Message, MessageSender};
 use yew::ComponentLink;
 
 type SingleArgClosure = Closure<dyn FnMut(JsValue)>;
@@ -342,8 +347,9 @@ impl NetworkManager for WebRTCManager {
 
                     console::log_1(&rtc_session_description.clone().into());
 
-                    web_rtc_manager_rc_clone.borrow_mut().offer =
-                        Some(String::from(JSON::stringify(&rtc_session_description).unwrap()));
+                    web_rtc_manager_rc_clone.borrow_mut().offer = Some(String::from(
+                        JSON::stringify(&rtc_session_description).unwrap(),
+                    ));
 
                     let set_local_description_exception_handler =
                         WebRTCManager::get_exception_handler(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,8 @@ mod chat;
 use chat::chat_model::*;
 
 use crate::chat::web_rtc_manager::WebRTCManager;
-#[allow(unused_imports)]
-use yew::{html, App, Callback, Component, ComponentLink, Html, InputData, ShouldRender};
+
+use yew::App;
 
 // Called when the wasm module is instantiated
 #[wasm_bindgen(start)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use chat::chat_model::*;
 
 #[allow(unused_imports)]
 use yew::{html, App, Callback, Component, ComponentLink, Html, InputData, ShouldRender};
+use crate::chat::web_rtc_manager::WebRTCManager;
 
 // Called when the wasm module is instantiated
 #[wasm_bindgen(start)]
@@ -20,7 +21,7 @@ pub fn main() -> Result<(), JsValue> {
 
     yew::initialize();
     let div = document.query_selector("#myRustApp").unwrap().unwrap();
-    App::<ChatModel>::new().mount(div);
+    App::<ChatModel<WebRTCManager>>::new().mount(div);
     yew::run_loop();
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,9 @@ mod chat;
 
 use chat::chat_model::*;
 
+use crate::chat::web_rtc_manager::WebRTCManager;
 #[allow(unused_imports)]
 use yew::{html, App, Callback, Component, ComponentLink, Html, InputData, ShouldRender};
-use crate::chat::web_rtc_manager::WebRTCManager;
 
 // Called when the wasm module is instantiated
 #[wasm_bindgen(start)]


### PR DESCRIPTION
Refactor that does not change any functionality, but improves code quality (and more importantly, readability).

Proposed changes:
- don't store all callback closures on WebRTCManager (this was done to preserve closures from being deleted, it is now done by calling Closure.forget()),
- rename WebRTCManager::create_default() to new(), return instance already wrapped in Rc and RefCell (as this is the only proper way to access the instance),
- hide usage of WebRTCManager behind an NetworkManager trait (shows which methods are required for functionality in the ChatModel and which are private helpers),
- remove unused code, delete all #[allow(unused_code)] and such,
- some clippy suggestions, substituting all start imports to better understand where do objects come from.